### PR TITLE
[742] add draft state in admin centre

### DIFF
--- a/app/assets/stylesheets/admin/_admin.scss
+++ b/app/assets/stylesheets/admin/_admin.scss
@@ -27,6 +27,11 @@
 .button-danger {
   background-color: $red;
 }
+
+.button-draft {
+  @include button($grey-1);
+}
+
 // Fix for incorrect button baseline defined in GOV.UK frontend toolkit
 .button {
   padding: 0.475em 0.9375em 0.4625em;

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -45,8 +45,6 @@ class Admin::OpportunitiesController < Admin::BaseController
   end
 
   def create
-    # @show_draft_button = policy(@opportunity).draft?
-
     opportunity_status = params[:commit] == 'Save to Draft' ? :draft : :pending
 
     @opportunity = CreateOpportunity.new(current_editor, opportunity_status).call(create_opportunity_params)
@@ -165,7 +163,7 @@ class Admin::OpportunitiesController < Admin::BaseController
 
     case opportunity.status
     when 'draft'
-      ButtonData.new(policy(opportunity).restore?, 'Pending', path, status: 'pending')
+      ButtonData.new(policy(opportunity).uploader_restore?, 'Pending', path, status: 'pending')
     else
       ButtonData.new(false)
     end

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -31,6 +31,8 @@ class Admin::OpportunitiesController < Admin::BaseController
     @history = OpportunityHistory.new(opportunity: @opportunity)
 
     @publishing_button_data = publishing_button_data(@opportunity)
+    @drafting_button_data = drafting_button_data(@opportunity)
+    @pending_button_data = pending_button_data(@opportunity)
     @show_trash_button = policy(@opportunity).trash?
     authorize @opportunity
   end
@@ -43,11 +45,19 @@ class Admin::OpportunitiesController < Admin::BaseController
   end
 
   def create
-    @opportunity = CreateOpportunity.new(current_editor).call(create_opportunity_params)
+    # @show_draft_button = policy(@opportunity).draft?
+
+    opportunity_status = params[:commit] == 'Save to Draft' ? :draft : :pending
+
+    @opportunity = CreateOpportunity.new(current_editor, opportunity_status).call(create_opportunity_params)
     authorize @opportunity
 
     if @opportunity.errors.empty?
-      redirect_to admin_opportunities_path, notice: %(Created opportunity "#{@opportunity.title}")
+      if opportunity_status == :pending
+        redirect_to admin_opportunities_path, notice: %(Created opportunity "#{@opportunity.title}")
+      elsif opportunity_status == :draft
+        redirect_to admin_opportunities_path, notice: %(Saved to draft: "#{@opportunity.title}")
+      end
     else
       load_options_for_form(@opportunity)
       setup_opportunity_contacts(@opportunity)
@@ -134,6 +144,28 @@ class Admin::OpportunitiesController < Admin::BaseController
       ButtonData.new(policy(opportunity).publishing?, 'Publish', path, status: 'publish')
     when 'trash'
       ButtonData.new(policy(opportunity).restore?, 'Restore', path, status: 'pending')
+    else
+      ButtonData.new(false)
+    end
+  end
+
+  def drafting_button_data(opportunity)
+    path = admin_opportunity_status_path(opportunity)
+
+    case opportunity.status
+    when 'trash'
+      ButtonData.new(policy(opportunity).draft?, 'Draft', path, status: 'draft')
+    else
+      ButtonData.new(false)
+    end
+  end
+
+  def pending_button_data(opportunity)
+    path = admin_opportunity_status_path(opportunity)
+
+    case opportunity.status
+    when 'draft'
+      ButtonData.new(policy(opportunity).restore?, 'Pending', path, status: 'pending')
     else
       ButtonData.new(false)
     end

--- a/app/controllers/admin/opportunity_status_controller.rb
+++ b/app/controllers/admin/opportunity_status_controller.rb
@@ -3,9 +3,16 @@ class Admin::OpportunityStatusController < Admin::BaseController
 
   def update
     opportunity = Opportunity.find(params[:opportunity_id])
-    authorize(opportunity, :publishing?)
 
     new_status = params[:status]
+
+    if new_status == 'draft'
+      authorize(opportunity, :drafting?)
+    elsif new_status == 'pending' && opportunity.status == 'draft'
+      authorize(opportunity, :restore?)
+    else
+      authorize(opportunity, :publishing?)
+    end
     result = UpdateOpportunityStatus.new.call(opportunity, new_status)
 
     if result.success?

--- a/app/controllers/admin/opportunity_status_controller.rb
+++ b/app/controllers/admin/opportunity_status_controller.rb
@@ -9,7 +9,7 @@ class Admin::OpportunityStatusController < Admin::BaseController
     if new_status == 'draft'
       authorize(opportunity, :drafting?)
     elsif new_status == 'pending' && opportunity.status == 'draft'
-      authorize(opportunity, :restore?)
+      authorize(opportunity, :uploader_restore?)
     else
       authorize(opportunity, :publishing?)
     end

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -38,7 +38,7 @@ class Opportunity < ActiveRecord::Base
   TITLE_LENGTH_LIMIT = 80.freeze
   TEASER_LENGTH_LIMIT = 140.freeze
 
-  enum status: { pending: 1, publish: 2, trash: 4 }
+  enum status: { pending: 1, publish: 2, draft: 3, trash: 4 }
 
   include PgSearch
 
@@ -53,6 +53,7 @@ class Opportunity < ActiveRecord::Base
 
   scope :published, -> { where(status: Opportunity.statuses[:publish]) }
   scope :applicable, -> { where('response_due_on >= ?', Time.zone.today) }
+  scope :drafted, -> { where(status: Opportunity.statuses[:draft]) }
 
   belongs_to :service_provider, required: true
   belongs_to :author, class_name: 'Editor', required: true

--- a/app/policies/opportunity_policy.rb
+++ b/app/policies/opportunity_policy.rb
@@ -12,7 +12,7 @@ class OpportunityPolicy < ApplicationPolicy
   end
 
   def edit?
-    return true if editor_is_record_owner? && @record.pending?
+    return true if editor_is_record_owner? && (@record.pending? || @record.trash? || @record.draft?)
     editor_is_admin_or_publisher?
   end
 
@@ -24,12 +24,20 @@ class OpportunityPolicy < ApplicationPolicy
     editor_is_admin_or_publisher?
   end
 
+  def drafting?
+    draft?
+  end
+
   def trash?
-    @editor.role == 'administrator' && @record.pending?
+    (@editor.role == 'administrator' && @record.pending?) || (@editor.role == 'uploader' && @record.status == 'draft' && editor_is_record_owner?)
   end
 
   def restore?
     @editor.role == 'administrator' && @record.trash?
+  end
+
+  def draft?
+    @editor.role == 'uploader' && @record.status == 'trash' && editor_is_record_owner?
   end
 
   private

--- a/app/policies/opportunity_policy.rb
+++ b/app/policies/opportunity_policy.rb
@@ -29,11 +29,15 @@ class OpportunityPolicy < ApplicationPolicy
   end
 
   def trash?
-    (@editor.role == 'administrator' && @record.pending?) || (@editor.role == 'uploader' && @record.status == 'draft' && editor_is_record_owner?)
+    (@editor.role == 'administrator' && (@record.pending? || @record.draft?)) || (@editor.role == 'uploader' && @record.status == 'draft' && editor_is_record_owner?)
   end
 
   def restore?
     @editor.role == 'administrator' && @record.trash?
+  end
+
+  def uploader_restore?
+    @editor.role == 'uploader' && @record.status == 'draft' && editor_is_record_owner?
   end
 
   def draft?

--- a/app/services/create_opportunity.rb
+++ b/app/services/create_opportunity.rb
@@ -1,6 +1,7 @@
 class CreateOpportunity
-  def initialize(editor)
+  def initialize(editor, status = :pending)
     @editor = editor
+    @status = status
   end
 
   def call(params)
@@ -10,7 +11,7 @@ class CreateOpportunity
       opportunity.slug = CreateOpportunitySlug.call(opportunity)
     end
 
-    opportunity.status = :pending
+    opportunity.status = @status
     opportunity.author = @editor
     opportunity.save
 

--- a/app/services/update_opportunity_status.rb
+++ b/app/services/update_opportunity_status.rb
@@ -16,6 +16,8 @@ class UpdateOpportunityStatus
       end
     when 'pending'
       change_status(opportunity, status)
+    when 'draft'
+      change_status(opportunity, status)
     else
       raise ArgumentError, 'Only statuses of publish and pending can be set'
     end
@@ -53,6 +55,8 @@ class UpdateOpportunityStatus
         'has been published'
       when 'pending'
         'has been set to pending'
+      when 'draft'
+        'has been set to draft'
       end
     end
   end

--- a/app/views/admin/opportunities/_form.html.haml
+++ b/app/views/admin/opportunities/_form.html.haml
@@ -106,3 +106,5 @@
     .column-one-half
       .form-group
         = f.submit class: 'button'
+        - if current_page?(action: 'new')
+          = f.submit 'Save to Draft', class: 'button button-draft'

--- a/app/views/admin/opportunities/show.html.haml
+++ b/app/views/admin/opportunities/show.html.haml
@@ -37,6 +37,12 @@
         - if @show_trash_button
           .inline-item
             =button_to('Trash', admin_opportunity_status_path(@opportunity), method: :delete, class: "button button-danger")
+        - if @drafting_button_data.show
+          .inline-item
+            =button_to(@drafting_button_data.text, @drafting_button_data.path, method: :patch, params: @drafting_button_data.params, class: "button")
+        - if @pending_button_data.show
+          .inline-item
+            =button_to(@pending_button_data.text, @pending_button_data.path, method: :patch, params: @pending_button_data.params, class: "button")
   %tr
     %th{:scope => 'row'} Countries
     %td= @opportunity.countries.map(&:name).join(', ')

--- a/production_deployment.sh~
+++ b/production_deployment.sh~
@@ -1,0 +1,2 @@
+#!/bin/bash
+git push heroku master && heroku run rake db:migrate && heroku restart

--- a/spec/factories/opportunities.rb
+++ b/spec/factories/opportunities.rb
@@ -15,6 +15,10 @@ FactoryGirl.define do
       status { :publish }
     end
 
+    trait :drafted do
+      status { :draft }
+    end
+
     trait :unpublished do
       status { :pending }
     end

--- a/spec/features/admin_trashes_an_opportunity_spec.rb
+++ b/spec/features/admin_trashes_an_opportunity_spec.rb
@@ -57,7 +57,18 @@ feature 'Trashing opportunities' do
     expect(page).to have_content('Trashed Opportunity')
   end
 
-  scenario 'Non-admin restoring a trashed opportunity' do
+  scenario 'Publisher restoring a trashed opportunity' do
+    uploader = create(:publisher)
+    opportunity = create(:opportunity, title: 'Trashed Opportunity', author: uploader, status: :trash)
+
+    login_as(uploader)
+
+    visit "/admin/opportunities/#{opportunity.id}"
+    expect(page).to have_content('Trashed Opportunity')
+    expect(page).to have_no_button('Restore')
+  end
+
+  scenario 'Uploader restoring a trashed opportunity' do
     uploader = create(:uploader)
     opportunity = create(:opportunity, title: 'Trashed Opportunity', author: uploader, status: :trash)
 
@@ -65,6 +76,7 @@ feature 'Trashing opportunities' do
 
     visit "/admin/opportunities/#{opportunity.id}"
     expect(page).to have_content('Trashed Opportunity')
+    expect(page).to have_button('Draft')
     expect(page).to have_no_button('Restore')
   end
 end

--- a/spec/features/administering_opportunities_spec.rb
+++ b/spec/features/administering_opportunities_spec.rb
@@ -132,6 +132,36 @@ feature 'Administering opportunities' do
     expect(page).to have_text('Created opportunity "A chance to begin again in a golden land of opportunity and adventure"')
   end
 
+  scenario 'Creating a draft opportunity by an Uploader' do
+    uploader = create(:uploader)
+    service_provider = create_service_provider('Italy Rome')
+
+    login_as(uploader)
+    visit admin_opportunities_path
+    click_on 'New opportunity'
+
+    fill_in 'Title', with: 'A chance to begin again in a golden land of opportunity and adventure'
+    fill_in t('admin.opportunity.teaser_field'), with: 'A new life awaits you in the off-world colonies!'
+    select '2016', from: 'opportunity_response_due_on_1i'
+    select 'July', from: 'opportunity_response_due_on_2i'
+    select '4', from: 'opportunity_response_due_on_3i'
+    fill_in t('admin.opportunity.description_field'), with: 'Replicants are like any other machine. They’re either a benefit or a hazard. If they’re a benefit, it’s not my problem.'
+    select service_provider.name, from: 'Service provider'
+
+    name_fields = find_all(:fillable_field, 'Name')
+    email_fields = find_all(:fillable_field, 'Email')
+
+    name_fields[0].set 'Jane Doe'
+    email_fields[0].set 'jane.doe@example.com'
+    name_fields[1].set 'Joe Bloggs'
+    email_fields[1].set 'joe.bloggs@example.com'
+
+    click_on 'Save to Draft'
+
+    expect(page.status_code).to eq 200
+    expect(page).to have_text('Saved to draft: "A chance to begin again in a golden land of opportunity and adventure"')
+  end
+
   scenario 'Editing an opportunity' do
     admin = create(:admin)
     opportunity = create_opportunity(admin, status: 'pending')

--- a/spec/features/uploaders_can_create_drafts_spec.rb
+++ b/spec/features/uploaders_can_create_drafts_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+feature 'Uploaders can create drafts' do
+  scenario 'and view their own drafted opportunities' do
+    uploader = create(:uploader)
+    opportunity = create(:opportunity, :drafted, author: uploader)
+
+    login_as(uploader)
+    visit admin_opportunities_path
+
+    click_on 'Draft'
+
+    expect(page.status_code).to eq 200
+    expect(page).to have_content(opportunity.title)
+  end
+
+  scenario 'and set it to trash' do
+    uploader = create(:uploader)
+    opportunity = create(:opportunity, :drafted, author: uploader)
+
+    login_as(uploader)
+    visit admin_opportunities_path
+
+    click_on 'Draft'
+    click_on opportunity.title
+
+    expect(page.status_code).to eq 200
+
+    click_on 'Trash'
+    expect(page.status_code).to eq 200
+    expect(page).to have_content('This opportunity was moved to Trash')
+  end
+
+  scenario 'and set it to pending' do
+  end
+
+  scenario 'and change the opportunity status to drafted from trash and back' do
+    uploader = create(:uploader)
+    opportunity = create(:opportunity, author: uploader, status: :trash)
+
+    login_as(uploader)
+    visit admin_opportunities_path
+
+    click_on opportunity.title
+
+    expect(page.status_code).to eq 200
+
+    click_on 'Draft'
+
+    expect(page.status_code).to eq 200
+    expect(page).to have_content('This opportunity has been set to draft')
+
+    click_on 'Trash'
+
+    expect(page).to have_content('This opportunity was moved to Trash')
+  end
+
+  scenario 'Other Uploaders cant view my uploaders drafted opportunities' do
+    service_provider = create(:service_provider, name: 'Provider of services')
+
+    uploader = create(:uploader, service_provider: service_provider)
+    opportunity = create(:opportunity, :drafted, author: uploader)
+
+    secret_uploader = create(:uploader, service_provider: service_provider)
+    secret_opportunity = create(:opportunity, :drafted, author: secret_uploader)
+
+    login_as(uploader)
+    visit admin_opportunities_path
+
+    expect(page).to have_content(opportunity.title)
+    expect(page).to_not have_content(secret_opportunity.title)
+  end
+
+  scenario 'Admins can view uploaders draft opportunities' do
+    uploader = create(:uploader)
+    opportunity = create(:opportunity, :drafted, author: uploader)
+
+    sneaky_admin = create(:admin)
+
+    login_as(sneaky_admin)
+    visit admin_opportunities_path
+
+    expect(page).to have_content(opportunity.title)
+  end
+end

--- a/spec/features/uploaders_can_create_drafts_spec.rb
+++ b/spec/features/uploaders_can_create_drafts_spec.rb
@@ -32,6 +32,20 @@ feature 'Uploaders can create drafts' do
   end
 
   scenario 'and set it to pending' do
+    uploader = create(:uploader)
+    opportunity = create(:opportunity, :drafted, author: uploader)
+
+    login_as(uploader)
+    visit admin_opportunities_path
+
+    click_on 'Draft'
+    click_on opportunity.title
+
+    expect(page.status_code).to eq 200
+
+    click_on 'Pending'
+    expect(page.status_code).to eq 200
+    expect(page).to have_content('This opportunity has been set to pending')
   end
 
   scenario 'and change the opportunity status to drafted from trash and back' do

--- a/spec/features/viewing_opportunities_spec.rb
+++ b/spec/features/viewing_opportunities_spec.rb
@@ -5,10 +5,12 @@ RSpec.feature 'Viewing opportunities' do
     valid_opportunity = create(:opportunity, status: :publish)
     create(:opportunity, status: :pending)
     create(:opportunity, status: :trash)
+    create(:opportunity, status: :draft)
 
     create(:opportunity, :expired, status: :publish)
     create(:opportunity, :expired, status: :pending)
     create(:opportunity, :expired, status: :trash)
+    create(:opportunity, :expired, status: :draft)
 
     visit opportunities_path
 

--- a/spec/services/update_opportunity_status_spec.rb
+++ b/spec/services/update_opportunity_status_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe UpdateOpportunityStatus do
     end
 
     it 'disallows some statuses' do
-      %w(draft trash).each do |disallowed_status|
+      %w(trash).each do |disallowed_status|
         opportunity = create(:opportunity)
         expect { described_class.new.call(opportunity, disallowed_status) }
           .to raise_error(ArgumentError)


### PR DESCRIPTION
Draft state initial functionality.

- On creating a new opp a user can Create(set to pending state) or Save to Draft(state=draft)
- An uploader can move an opp from the show view to these states trash<->draft -> pending . Once it's pending state, it's out of her control and to the editor's/admin's control
- Drafts are private to uploaders
- Admins can view and modify drafts
