### PR TITLE
Add indication of character limit

### DIFF
--- a/app/assets/javascripts/enquiries_form.js
+++ b/app/assets/javascripts/enquiries_form.js
@@ -1,5 +1,6 @@
 (function() {
   "use strict";
+
   function renderResults(data) {
     $("#ch_search-results ul").empty();
     if (data.length < 1) {
@@ -70,7 +71,40 @@
     });
   }
 
+  /* Class: RestrictedInput
+   * --------------------------------
+   * Adds an input limit message after an Input or Textarea field, that
+   * counts down remaining characters until the maximum is reached.
+   * Maximum character limit is specified by the maxlength attribute.
+   **/
+  function RestrictedInput($target) {
+    var $remaining = $(document.createElement("span"));
+    var $message = $(document.createElement("p"));
+    var text = "characters remaining";
+    var max = 0;
+
+    if($target.length) {
+      max = $target.attr("maxlength");
+
+      $target.on("input", function() {
+        var remaining = max - this.value.length;
+        if(remaining <= 0) {
+          this.value = this.value.substr(0, max);
+        }
+        $remaining.text(max - this.value.length);
+      });
+
+      $remaining.text(max);
+      $message.text(" " + text);
+      $message.prepend($remaining);
+      $target.after($message);
+    }
+  }
+
   $('document').ready(function() {
+    new RestrictedInput($("#enquiry_company_explanation"));
+
+    // Only when Companies House search field present
     if ($("#ch_search").length) {
       noCHnumberSetup();
 

--- a/app/views/enquiries/new.html.haml
+++ b/app/views/enquiries/new.html.haml
@@ -88,7 +88,7 @@
                   = f.label :company_explanation, class: "required" do
                     Explain what your company does and how it meets the requirements for this opportunity. This is your chance to promote your company and make your proposal stand out.
                     %small (max. 1100 characters)
-              = f.text_area :company_explanation, {required: "required", rows: "8", maxlength: "1100"}
+              = f.text_area :company_explanation, {required: "required", rows: "8"}
 
             .form-group
               %label

--- a/app/views/enquiries/new.html.haml
+++ b/app/views/enquiries/new.html.haml
@@ -85,8 +85,10 @@
             .form-group
               .row.collapse
                 .column-9
-                  = f.label :company_explanation, "Explain what your company does and how it meets the requirements for this opportunity. This is your chance to promote your company and make your proposal stand out.", class: "required"
-              = f.text_area :company_explanation, {required: "required", rows: "8"}
+                  = f.label :company_explanation, class: "required" do
+                    Explain what your company does and how it meets the requirements for this opportunity. This is your chance to promote your company and make your proposal stand out.
+                    %small (max. 1100 characters)
+              = f.text_area :company_explanation, {required: "required", rows: "8", maxlength: "1100"}
 
             .form-group
               %label

--- a/spec/features/users_can_apply_for_opportunities_spec.rb
+++ b/spec/features/users_can_apply_for_opportunities_spec.rb
@@ -120,6 +120,36 @@ RSpec.feature 'users can apply for opportunities', js: true do
     end
   end
 
+  scenario 'user can not apply with more than 1100 characters in company description' do
+    opportunity = create(:opportunity, status: 'publish')
+    create(:sector)
+
+    visit "enquiries/#{opportunity.slug}"
+
+    fill_in_form
+    fake_description = Faker::Lorem.characters(1101)
+    fill_in :enquiry_company_explanation, with: fake_description
+
+    click_on 'Submit'
+
+    expect(page).not_to have_content('Thank you')
+  end
+
+  scenario 'user can apply with exactly 1100 characters in company description', js: true do
+    opportunity = create(:opportunity, status: 'publish')
+    create(:sector)
+
+    visit "enquiries/#{opportunity.slug}"
+
+    fill_in_form
+    fake_description = Faker::Lorem.characters(1100)
+    fill_in :enquiry_company_explanation, with: fake_description
+
+    click_on 'Submit'
+
+    expect(page).to have_content('Thank you')
+  end
+
   scenario 'user enquiries are emailed to DIT' do
     allow(Figaro.env).to receive(:enquiries_cc_email).and_return('dit-cc@example.org')
     clear_email


### PR DESCRIPTION
Note: Have specified 1100 character limit on field, and code indicates similar restriction...
`app/models/enquiry.rb:  COMPANY_EXPLANATION_MAXLENGTH = 1100.freeze`
but when submitted with this number, the error message still shows. 

Reducing the character limit to 1098 appears to be the maximum that can be submitted with being served the error. 

