### PR TITLE
Add Filter Expanders to dit.page.results

### DIFF
--- a/app/assets/javascripts/poc/dit.class.expander.js
+++ b/app/assets/javascripts/poc/dit.class.expander.js
@@ -124,19 +124,19 @@
   Expander.bindEvents = function() {
     var EXPANDER = this;
     
-    Expander.AddKeyboardSupport.call(EXPANDER);
+    Expander.addKeyboardSupport.call(EXPANDER);
     
     if (EXPANDER.config.hover) {
-      Expander.AddHoverSupport.call(EXPANDER);
+      Expander.addHoverSupport.call(EXPANDER);
     }
     else {
-      Expander.AddClickSupport.call(EXPANDER);
+      Expander.addClickSupport.call(EXPANDER);
     }
   }
   
   /* Add ability to control by keyboard
    **/
-  Expander.AddKeyboardSupport = function() {
+  Expander.addKeyboardSupport = function() {
     var EXPANDER = this;
     
     EXPANDER.$control.on(KEY, function(event) {
@@ -168,7 +168,7 @@
 
   /* Add Hover events (for desktop only)
    **/
-  Expander.AddHoverSupport = function() {
+  Expander.addHoverSupport = function() {
     var EXPANDER = this;
     var $node = EXPANDER.$node;
 
@@ -189,7 +189,7 @@
   
   /* Using click for desktop and mobile.
    **/
-  Expander.AddClickSupport = function() {
+  Expander.addClickSupport = function() {
     var EXPANDER = this;
 
     EXPANDER.$control.on(CLICK, function(event) {

--- a/app/assets/javascripts/poc/layouts/results.js
+++ b/app/assets/javascripts/poc/layouts/results.js
@@ -4,13 +4,13 @@
 //= require ../dit.class.filter_select
 
 dit.page.results = (new function () {
-  var _results = this;
+  var RESULTS = this;
   var _cache = {
   }
   
   // Page init
   this.init = function() {
-    enhanceIndustrySelector();
+    enhanceResultFilters();
 
     cacheComponents();
     viewAdjustments(dit.responsive.mode());
@@ -53,14 +53,15 @@ dit.page.results = (new function () {
    * Note: We get the groups and labels outside the loop
    * to avoid issues with closures.
    **/
-  function enhanceIndustrySelector() {
+  function enhanceResultFilters() {
+    RESULTS.expanders = [];
     $groups = $(".search-results-filters fieldset");
     $labels = $groups.find("legend");
     $groups.each(function(index) {
-      new dit.classes.Expander($(this), {
+      RESULTS.expanders.push(new dit.classes.Expander($(this), {
         $control: $labels.eq(index),
         blur: false
-      });
+      }));
     });
   }
 


### PR DESCRIPTION
On Search Results page, enhanced filters (open and close expanders) will not be accessible via scoped JS. To test, visit...
`http://localhost:3000/poc/opportunities?filterOpen=&industries%5B%5D=aerospace&isSearchAndFilter=true&paged=2&s=food`

...in a browser and use the Inspector Console to run:
`dit.page.results.expanders[0].open()`

You should see the Regions filter now open. Use `.close()` to reverse the action.

dit is an object on the window scope (so, full location is window.dit.page.results...)