### PR TITLE
(fix) monitoring /api_check endpoint

### DIFF
--- a/spec/features/webops_can_monitor_elastic_search_spec.rb
+++ b/spec/features/webops_can_monitor_elastic_search_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 feature 'webops can monitor services' do
+  before(:each) do
+    @redis =  Redis.new(url: Figaro.env.redis_url!)
+    @redis.del(:sidekiq_retry_jobs_last_failure)
+  end
+
   scenario 'elastic search, basic check, all is OK' do
     allow_any_instance_of(ApplicationController).to receive(:db_opportunities).and_return ['8c11755c-3c39-44cd-8b4e-7527bbc7aa10', '5bb688c2-391e-490a-9e4b-d0183040e9de']
     allow_any_instance_of(ApplicationController).to receive(:es_opportunities).and_return ['8c11755c-3c39-44cd-8b4e-7527bbc7aa10', '5bb688c2-391e-490a-9e4b-d0183040e9de']
@@ -57,22 +62,40 @@ feature 'webops can monitor services' do
     expect(res['result']['subscriptions']['missing'].first).to eq('5bb688c2-391e-490a-9e4b-d0183040e9de')
   end
 
-  scenario 'api check, we have failed jobs' do
-    allow(Figaro.env).to receive(:OO_HOSTNAME!) { 'http://www.aninvaliddomain.com' }
-
-    # reset sidekiq counter
-    rs = Sidekiq::RetrySet.new
-    rs.clear
-
-    # add sidekiq job that will fail on retry
-
+  scenario 'api check, no error' do
+    allow_any_instance_of(ApplicationController).to receive(:sidekiq_retry_count).and_return 0
+    allow_any_instance_of(ApplicationController).to receive(:redis_oo_retry_count).and_return 0
 
     visit '/api_check'
 
-    expect(page.body).to have_content("\"retry_error_count\":1")
+    expect(page.body).to have_content("OK")
+  end
 
-    # reset sidekiq counter again
-    rs.clear
-    byebug
+  scenario 'api check, 1 new error' do
+    allow_any_instance_of(ApplicationController).to receive(:sidekiq_retry_count).and_return 1
+    allow_any_instance_of(ApplicationController).to receive(:redis_oo_retry_count).and_return 0
+
+    visit '/api_check'
+
+    expect(page.body).to have_content("error")
+  end
+
+  scenario 'api check, 1 new error, more than 1 day ago' do
+    allow_any_instance_of(ApplicationController).to receive(:sidekiq_retry_count).and_return 1
+    allow_any_instance_of(ApplicationController).to receive(:redis_oo_retry_count).and_return 0
+
+    visit '/api_check'
+
+    expect(page.body).to have_content("error")
+
+    tomorrow = Time.zone.now + 1.day + 1.minute
+    Timecop.freeze(tomorrow) do
+      allow_any_instance_of(ApplicationController).to receive(:sidekiq_retry_count).and_return 1
+      allow_any_instance_of(ApplicationController).to receive(:redis_oo_retry_count).and_return 0
+
+      visit '/api_check'
+
+      expect(page.body).to have_content("OK")
+    end
   end
 end


### PR DESCRIPTION
new /api_check endpoint, will notice a new failed job in sidekiq based on JobQueue name, start failing, continue complaining for a day.