### PR TITLE
Fix attempt for weird IE issue

### DIFF
--- a/app/views/opportunities/_search_form.html.haml
+++ b/app/views/opportunities/_search_form.html.haml
@@ -1,4 +1,4 @@
-= form_tag opportunities_path, class: 'search-form', method: :get do
+%form.search-form{:action=>opportunities_path, :method=>"get"}
   %label.term
     %span.verbose Product or service keyword
     %input{:name=>"s", :placeholder=>"What product or service are you selling?", :autocomplete=>"off", :type=>"search"}


### PR DESCRIPTION
This is an attempt to see if removing the 'tick' parameter (originally intended as a Rails fix for older IE browsers), makes any difference in the weird 'clear all filters' issue that affects only IE (the one where a page refresh shows a working page). 

It is a 'have nothing else to offer' attempt to avoid putting in the auto-refresh hack that has been discussed. 