### PR TITLE
(feat) Decrease thread and process limits

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -58,10 +58,10 @@ daemonize false
 port Integer(ENV.fetch('PORT', 3000))
 environment ENV['RAILS_ENV'] || 'development'
 
-thread_count = Integer(ENV.fetch('THREADS', 30))
+thread_count = Integer(ENV.fetch('THREADS', 15))
 threads thread_count, thread_count
 
-workers Integer(ENV.fetch('PROCESSES', 8))
+workers Integer(ENV.fetch('PROCESSES', 4))
 
 preload_app!
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -58,10 +58,10 @@ daemonize false
 port Integer(ENV.fetch('PORT', 3000))
 environment ENV['RAILS_ENV'] || 'development'
 
-thread_count = Integer(ENV.fetch('THREADS', 15))
+thread_count = Integer(ENV.fetch('THREADS', 16))
 threads thread_count, thread_count
 
-workers Integer(ENV.fetch('PROCESSES', 4))
+workers Integer(ENV.fetch('PROCESSES', 8))
 
 preload_app!
 


### PR DESCRIPTION
From testing on staging, these (and similar) changes reduced frequency of 502s
and booted workers. It did not completely eliminate them however.

----

On production, there are 900 threads, spread over 4 instances, 8 processes per
instance, 30 threads per process, 8G memory per instance. If each thread used
as much memory as it could, at most 33mb per thread. Some brief heap analysis
locally appeared to show that starting a thread takes ~30mb of memory, so this
appears to be too low.

Also, there are documented 500 max connections to the database being used, so
even if all of these threads could be used at once, many would fail.

There are also (apparently) max of 4 cores on each instance: so in terms of
parallel processing, there can never be more than 4 instructions being executed
in parallel at any given time on any instance.

So, to determine better values for threads and process, say we examine two
“extreme” applications...

CPU bound application, where the GIL effect would be strong
- Number of process should be ~the number of CPUs, and 1 thread per process.
  Other options needless use more memory, increase context switching, or
  blocking on the GIL.

IO bound application, where the GIL effect would be negligable
- Should have 1 process, higher number of threads, up to whatever limit IO can
  be done in parallel without slowdown. Other options (i.e. high number of
  processes, fewer threads), would needlessly use more memory (each process has
  its own copy of all the Ruby code etc..).

Considering the above, even an application of a mixture of IO and CPU, if there
maximum of 4 cores available, there isn't any case 8 processes would be better
than 4 processes.

If there are 4 processes per instance (down from the 8 now), then we must
decide how many threads per process (noting there are 30 now). To never exhaust
database connections, which is documented to be 500, if we have between 1 and 8
application instances, and in the “worst” case of 8 instances

- DB connections per instance:  500/8 = 62.5 per instance
- 4 processes per instances gives 62.5 / 4 = 15.625 threads per process

Max concurrent requests that could be served by the cluster, even if it was
dropped to a single instance, would still be 15 * 4 = 60. At 4 instances (which
is how many there are currently), this would be 240. Quickly increasing load
would still be able to be handled without failure (at least, no greater chance
of failure than now), since they would be queued by Puma.

However, from the available data, but it looks like there is a rough max of 5
concurrent requests at any given time. Even 1 instance running gives a lot of
room to handle incoming requests without them queueing up.

Memory-wise, if each thread used as much as it could, then memory per thread
would be 8GB/(4*15) = 133mb, which feels much safer than the 33mb now.

- Recommendation: reduce processes per instance from 8 to 4, threads per
  process from 30 to 15.