### PR TITLE
(feat) Use yajl for dumping json. It's already a dependency...

### DIFF
--- a/app/controllers/api/activity_stream_controller.rb
+++ b/app/controllers/api/activity_stream_controller.rb
@@ -1,6 +1,6 @@
 require 'base64'
 require 'digest'
-require 'json'
+require 'yajl'
 require 'openssl'
 
 def to_activity_collection(activities)
@@ -152,14 +152,14 @@ module Api
         error_object = {
           message: message,
         }
-        format.json { render status: code, json: error_object.to_json }
+        format.json { render status: code, json: Yajl::Encoder.encode(error_object) }
       end
     end
 
     def respond_200(contents)
       respond_to do |format|
         response.headers['Content-Type'] = 'application/activity+json'
-        format.json { render status: 200, json: contents.to_json }
+        format.json { render status: 200, json: Yajl::Encoder.encode(contents) }
       end
     end
 


### PR DESCRIPTION
... and it seems faster and uses less cpu:

<img width="525" alt="after-putting-yajl-on-cd-with-less-figaro" src="https://user-images.githubusercontent.com/13877/44627064-91ccd280-a91f-11e8-8f15-e7deceb711b3.png">

<img width="479" alt="after-putting-yajl-on-cd-cpu" src="https://user-images.githubusercontent.com/13877/44627060-8a0d2e00-a91f-11e8-8ae7-6851bfa20775.png">

These graphs were taken on CD when running code that had _both_ the code from there, and from https://github.com/uktrade/export-opportunities/pull/308 , and when the activity stream was pulling from CD (albeit only ~80 activities)