### PR TITLE
(fix) Deployments were scaling to 1gb of memory, suspect migrations not running

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-command: bundle exec rake cf:on_first_instance db:migrate && bundle exec puma -p ${PORT:-3000}
+web: bundle exec rake cf:on_first_instance db:migrate && bundle exec puma -p ${PORT:-3000}
 worker: bin/start-stunnel bundle exec sidekiq -C config/sidekiq.yml


### PR DESCRIPTION
A few bits of subtle behaviour here...

  - There was no existing "command" process running, so the CI pipeline did not
    instantiate a "command" process. This means the migrations were not
    running.

  - Without a "web" process specified, the default one in the buildback was
    running. In this case, the default one for the Ruby buildpack made
    everything work.

  - The default memory for a "web" process is also set to 1gb. Without it being
    specified in the Procfile, the CI pipeline script does not ensure to scale
    it to match the existing "web" process.