### PR TITLE
(feat) Cache classes: among other things, it caches compiled templates

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,7 +2,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
-  # config.cache_classes = true
+  config.cache_classes = true
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers


### PR DESCRIPTION
I'm suspecting compiling templates is slow, and possibly leaky looking at stack
dumps. Also, there has been IO problems in production, and I've seen checking
file modification times in Sentry errors, so this may go some way in addressing
those.