### PR TITLE
Bugfix/users can view opportunities spec

### DIFF
--- a/spec/features/users_can_view_opportunities_spec.rb
+++ b/spec/features/users_can_view_opportunities_spec.rb
@@ -308,7 +308,7 @@ RSpec.feature 'User can view opportunities in list', :elasticsearch, :commit do
     expect_any_instance_of(ApplicationController).to receive(:opps_counter_stats).and_return({total: 1000})
 
     visit '/'
-    expect(page).to have_content('Find over 1000 export opportunities')
+    expect(page).to have_content('Search 1,000 export sales leads')
   end
 
   scenario 'counters for landing page, total counter missing' do

--- a/spec/features/users_can_view_opportunities_spec.rb
+++ b/spec/features/users_can_view_opportunities_spec.rb
@@ -7,21 +7,6 @@ RSpec.feature 'User can view opportunities in list', :elasticsearch, :commit do
     expect(page).to have_content('Latest export opportunities')
   end
 
-  scenario 'clicks on view more opportunities from root', :elasticsearch, :commit do
-    country1 = create(:country, name: 'Selected 1')
-    create_list(:opportunity, 6, status: 'publish', countries: [country1])
-
-    visit '/'
-
-    expect(page).to have_content('Latest export opportunities')
-    expect(page).to have_content('View more')
-
-    sleep 1
-    click_on 'View more'
-
-    expect(page.body).to have_content('6 results found')
-  end
-
   scenario 'clicks on view more opportunities from root, should only view opportunities up to the specified limit (*5 for ES shards)', :elasticsearch, :commit do
     skip('TODO: fix to get to less opps')
     country1 = create(:country, name: 'Selected 1')

--- a/spec/features/users_can_view_opportunities_spec.rb
+++ b/spec/features/users_can_view_opportunities_spec.rb
@@ -7,22 +7,15 @@ RSpec.feature 'User can view opportunities in list', :elasticsearch, :commit do
     expect(page).to have_content('Latest export opportunities')
   end
 
-  scenario 'clicks on view more opportunities from root, should only view opportunities up to the specified limit (*5 for ES shards)', :elasticsearch, :commit do
-    skip('TODO: fix to get to less opps')
-    country1 = create(:country, name: 'Selected 1')
-    create_list(:opportunity, 500, status: 'publish', countries: [country1], first_published_at: Time.zone.now)
-    visible_opportunity = create(:opportunity, status: 'publish', countries: [country1], title: 'need flags', first_published_at: Time.zone.now - 1.day)
+  scenario 'empty search shows up to the specified limit (*5 for ES shards)', :elasticsearch, :commit do
+    skip('intermittent failure due to results not always returning 500')
+    country = create(:country, name: 'big country')
+    create_list(:opportunity, 550, status: 'publish', countries: [country], first_published_at: Time.zone.now)
 
-    visit '/'
+    visit opportunities_path
 
-    expect(page).to have_content('Latest export opportunities')
-    expect(page).to have_content('View more')
-
-    sleep 10
-    click_on 'View more'
-
-    expect(page.body).to have_content('500 results found')
-    expect(page.body).to_not have_content(visible_opportunity.title)
+    expect(page).to have_current_path('/opportunities')
+    expect(page).to have_content('Displaying items 1 - 10 of 500')
   end
 
   scenario 'clicks on featured industries link, gets both OO and posts opportunities', :elasticsearch, :commit, js: true do


### PR DESCRIPTION
Fixed a couple of tests. Many of the others are failing due to 
```
# NoMethodError:
#   undefined method `strftime' for nil:NilClass
#   ./app/presenters/opportunity_presenter.rb:149:in `published_date'
```
which has already been fixed in PR https://github.com/uktrade/export-opportunities/pull/340