### PR TITLE
Bugfix/XOT-498 add extra sign off to review page and form

### DIFF
--- a/app/content/opportunities/show.yml
+++ b/app/content/opportunities/show.yml
@@ -6,3 +6,11 @@ disclaimer_1: This website contains links to other websites that we do not contr
 disclaimer_2: Before entering into a contract you need to apply for any necessary export licences, which can include applications to trade in certain goods. You should also make your own enquiries and be satisfied by the accuracy of any information supplied to you.
 
 disclaimer_3: This opportunity has been translated from its original language. You should check if you need to apply in the original language.
+
+sign_off_dit: Express your interest to the Department for International Trade.
+sign_off_default: Express your interest to the Department for International Trade team in [$determiner][$place_name].
+sign_off_partner_1: Express your interest to the [$partner_name] in [$country_name].
+sign_off_partner_2: The [$partner_name] is our chosen partner to deliver trade services in [$country_name].
+sign_off_target_url: For more information and to make a bid you will need to go to the third party website.
+sign_off_volume_opps: If your company meets the requirements of the tender, go to the website where the tender is hosted and submit your bid.
+

--- a/app/content/opportunities/show.yml
+++ b/app/content/opportunities/show.yml
@@ -13,4 +13,4 @@ sign_off_partner_1: Express your interest to the [$partner_name] in [$country_na
 sign_off_partner_2: The [$partner_name] is our chosen partner to deliver trade services in [$country_name].
 sign_off_target_url: For more information and to make a bid you will need to go to the third party website.
 sign_off_volume_opps: If your company meets the requirements of the tender, go to the website where the tender is hosted and submit your bid.
-
+sign_off_extra: All submissions will be reviewed and you will be notified of any potential next steps. You can only express your interest if you are a UK registered company.

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -30,7 +30,7 @@ class Admin::OpportunitiesController < Admin::BaseController
   end
 
   def show
-    content = get_content('admin/opportunities.yml')
+    content = get_content('opportunities/show.yml', 'admin/opportunities.yml')
     @opportunity = Opportunity.includes(:enquiries).find(params[:id])
     @enquiries_cutoff = 20
     @comment_form = OpportunityCommentForm.new(opportunity: @opportunity, author: current_editor)
@@ -44,7 +44,7 @@ class Admin::OpportunitiesController < Admin::BaseController
   end
 
   def new
-    content = get_content('admin/opportunities.yml')
+    content = get_content('opportunities/show.yml', 'admin/opportunities.yml')
     @opportunity = Opportunity.new
     @save_to_draft_button = policy(@opportunity).uploader_previewer?
     @editor = current_editor
@@ -58,7 +58,7 @@ class Admin::OpportunitiesController < Admin::BaseController
   end
 
   def create
-    content = get_content('admin/opportunities.yml')
+    content = get_content('opportunities/show.yml', 'admin/opportunities.yml')
     status = if params[:commit] == content['submit_draft']
                :draft
              else
@@ -75,7 +75,6 @@ class Admin::OpportunitiesController < Admin::BaseController
         redirect_to admin_opportunity_path(@opportunity), notice: %(Saved to draft: "#{@opportunity.title}")
       end
     else
-      content = get_content('admin/opportunities.yml')
       @editor = current_editor
 
       load_options_for_form(@opportunity)
@@ -87,7 +86,7 @@ class Admin::OpportunitiesController < Admin::BaseController
   end
 
   def edit
-    content = get_content('admin/opportunities.yml')
+    content = get_content('opportunities/show.yml', 'admin/opportunities.yml')
     @opportunity = Opportunity.includes(comments: [:author]).find(params[:id])
     @comment_form = OpportunityCommentForm.new(opportunity: @opportunity, author: current_editor)
     @history = OpportunityHistory.new(opportunity: @opportunity)
@@ -104,7 +103,7 @@ class Admin::OpportunitiesController < Admin::BaseController
   end
 
   def update
-    content = get_content('admin/opportunities.yml')
+    content = get_content('opportunities/show.yml', 'admin/opportunities.yml')
     @opportunity = Opportunity.find(params[:id])
     authorize @opportunity
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -260,8 +260,12 @@ class ApplicationController < ActionController::Base
   # Note: Rails may already provide a similar service for multiple
   # language support, so this mechanism might be replaced by that
   # at some point in the furture.
-  def get_content(file)
-    YAML.load_file('app/content/' + file)
+  def get_content(*files)
+    content = {}
+    files.each do |file|
+      content = content.merge YAML.load_file('app/content/' + file)
+    end
+    content
   end
 
   def redis_oo_retry_count(redis)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -18,7 +18,11 @@ class ApplicationMailer < ActionMailer::Base
   # Note: Rails may already provide a similar service for multiple
   # language support, so this mechanism might be replaced by that
   # at some point in the furture.
-  def get_content(file)
-    YAML.load_file('app/content/' + file)
+  def get_content(*files)
+    content = {}
+    files.each do |file|
+      content = content.merge YAML.load_file('app/content/' + file)
+    end
+    content
   end
 end

--- a/app/presenters/admin_opportunity_presenter.rb
+++ b/app/presenters/admin_opportunity_presenter.rb
@@ -1,7 +1,6 @@
 class AdminOpportunityPresenter < OpportunityPresenter
   def initialize(view_context, opportunity, content)
-    super(view_context, opportunity)
-    @content = content
+    super(view_context, opportunity, content)
   end
 
   def edit_button

--- a/app/presenters/opportunity_presenter.rb
+++ b/app/presenters/opportunity_presenter.rb
@@ -185,8 +185,8 @@ class OpportunityPresenter < PagePresenter
       lines.push @content['sign_off_volume_opps']
 
     elsif partner.present?
-      lines.push content_with_inclusion('sign_off_partner_1', [partner, country.name])
-      lines.push content_with_inclusion('sign_off_partner_2', [partner, country.name])
+      lines.push content_with_inclusion('sign_off_partner_1', [partner, country_name])
+      lines.push content_with_inclusion('sign_off_partner_2', [partner, country_name])
 
     elsif ['DIT Education', 'DIT HQ', 'DSO HQ', 'DSO RD West 2 / NATO',
            'Occupied Palestinian Territories Jerusalem', 'UKEF', 'UKREP',
@@ -194,7 +194,7 @@ class OpportunityPresenter < PagePresenter
       lines.push @content['sign_off_dit']
 
     elsif name.match(/Czech Republic \w+|Dominican Republic \w+|Ivory Coast \w+|Netherlands \w+|Philippines \w+|United Arab Emirates \w+|United States \w+/)
-      lines.push content_with_inclusion('sign_off_default', ['the ', country.name])
+      lines.push content_with_inclusion('sign_off_default', ['the ', country_name])
 
     # Exceptions where we need to use Region name
     elsif name.match(/.*Africa.* \w+|Cameroon \w+|Egypt \w+|Kenya OBNI|Nabia \w+|Rwanda \w+|Senegal \w+|Seychelles \w+|Tanzania \w+|Tunisia \w+|Zambia \w+/)
@@ -202,7 +202,7 @@ class OpportunityPresenter < PagePresenter
 
     else
       # Default sign off
-      lines.push content_with_inclusion('sign_off_default', ['', country.name])
+      lines.push content_with_inclusion('sign_off_default', ['', country_name])
 
     end
     lines

--- a/app/presenters/opportunity_presenter.rb
+++ b/app/presenters/opportunity_presenter.rb
@@ -187,22 +187,27 @@ class OpportunityPresenter < PagePresenter
     elsif partner.present?
       lines.push content_with_inclusion('sign_off_partner_1', [partner, country_name])
       lines.push content_with_inclusion('sign_off_partner_2', [partner, country_name])
+      lines.push @content['sign_off_extra']
 
     elsif ['DIT Education', 'DIT HQ', 'DSO HQ', 'DSO RD West 2 / NATO',
            'Occupied Palestinian Territories Jerusalem', 'UKEF', 'UKREP',
            'United Kingdom LONDON', 'USA AFB', 'USA OBN OCO', 'USA OBN Sannam S4'].include? name
       lines.push @content['sign_off_dit']
+      lines.push @content['sign_off_extra']
 
     elsif name.match(/Czech Republic \w+|Dominican Republic \w+|Ivory Coast \w+|Netherlands \w+|Philippines \w+|United Arab Emirates \w+|United States \w+/)
       lines.push content_with_inclusion('sign_off_default', ['the ', country_name])
+      lines.push @content['sign_off_extra']
 
     # Exceptions where we need to use Region name
     elsif name.match(/.*Africa.* \w+|Cameroon \w+|Egypt \w+|Kenya OBNI|Nabia \w+|Rwanda \w+|Senegal \w+|Seychelles \w+|Tanzania \w+|Tunisia \w+|Zambia \w+/)
       lines.push content_with_inclusion('sign_off_default', ['', country.region.name])
+      lines.push @content['sign_off_extra']
 
     else
       # Default sign off
       lines.push content_with_inclusion('sign_off_default', ['', country_name])
+      lines.push @content['sign_off_extra']
 
     end
     lines

--- a/app/views/enquiries/new.html.haml
+++ b/app/views/enquiries/new.html.haml
@@ -1,6 +1,6 @@
 - page = PagePresenter.new(@content)
 - page.add_breadcrumb_current('Express interest')
-- opp = OpportunityPresenter.new(self, @opportunity)
+- opp = OpportunityPresenter.new(self, @opportunity, @content)
 
 .process
   .container

--- a/app/views/opportunities/show.html.haml
+++ b/app/views/opportunities/show.html.haml
@@ -151,15 +151,12 @@
           - opportunity.sign_off_content.each do |line|
             = content_tag("p", line, class: "sign-off")
 
+          = yield :disclaimer_content
+
           - if opportunity.target_url.present?
-            = yield :disclaimer_content
             = link_to 'Go to third party website', opportunity.target_url, class: 'button', target: :_blank
 
           - else
-            %p.sign-off 
-              All submissions will be reviewed and you will be notified of any potential next steps.
-              You can only express your interest if you are a UK registered company.
-            = yield :disclaimer_content
             = link_to 'Express your interest', new_enquiry_path(@opportunity.slug), class: 'button abcbutton'
 
         - else
@@ -167,6 +164,7 @@
           %h2 Bid for tender
           - opportunity.sign_off_content.each do |line|
             = content_tag("p", line, class: "sign-off")
+
           = yield :disclaimer_content
           = link_to 'Go to third party website', opportunity.tender_url, class: 'button', target: :_blank
 

--- a/app/views/opportunities/show.html.haml
+++ b/app/views/opportunities/show.html.haml
@@ -1,5 +1,5 @@
 - page = PagePresenter.new(@content)
-- opportunity = OpportunityPresenter.new(self, @opportunity)
+- opportunity = OpportunityPresenter.new(self, @opportunity, @content)
 - page.add_breadcrumb_current(opportunity.title_with_country)
 
 .container

--- a/spec/features/admin_login_spec.rb
+++ b/spec/features/admin_login_spec.rb
@@ -48,8 +48,7 @@ feature 'Logging in as an admin' do
 
     visit '/admin/help/how-to-write-an-export-opportunity/overview'
 
-    expect_editor_to_be_logged_in
-    expect(page.body).to include('This guidance aims to help you write export opportunities')
+    expect(page.body).to include('This guidance will help you write export opportunities.')
     expect(page.body).to include('How to write an export opportunity')
   end
 

--- a/spec/features/viewing_an_individual_opportunity_spec.rb
+++ b/spec/features/viewing_an_individual_opportunity_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Viewing an individual opportunity', :elasticsearch, :commit do
+  let(:service_provider) { create(:service_provider, country: create(:country)) }
+
   scenario 'pending and trashed opportunities are not accessible' do
     opportunities = [
       create(:opportunity, status: :pending),
@@ -14,7 +16,7 @@ RSpec.feature 'Viewing an individual opportunity', :elasticsearch, :commit do
   end
 
   scenario 'published but expired opportunities are accessible' do
-    create(:opportunity, :expired, status: :publish, title: 'Hairdressers wanted', slug: 'hairdressers-wanted')
+    create(:opportunity, :expired, status: :publish, title: 'Hairdressers wanted', slug: 'hairdressers-wanted', service_provider_id: service_provider.id)
 
     visit 'opportunities/hairdressers-wanted'
 
@@ -52,7 +54,7 @@ RSpec.feature 'Viewing an individual opportunity', :elasticsearch, :commit do
     types = create_list(:type, 5)
     countries = [create(:country, exporting_guide_path: '/somelink')]
 
-    opportunity = create(:opportunity, source: :post, status: 'publish', sectors: sectors, types: types, countries: countries)
+    opportunity = create(:opportunity, source: :post, status: 'publish', sectors: sectors, types: types, countries: countries, service_provider_id: service_provider.id)
 
     create_list(:enquiry, 3, opportunity: opportunity)
 
@@ -97,7 +99,8 @@ RSpec.feature 'Viewing an individual opportunity', :elasticsearch, :commit do
 
   scenario 'country with a link to exporting guide' do
     country = create(:country, exporting_guide_path: '/government/publications/exporting-to-egypt')
-    opportunity = create(:opportunity, status: :publish, response_due_on: 3.months.from_now, countries: [country])
+    opportunity = create(:opportunity, status: :publish, response_due_on: 3.months.from_now, countries: [country], service_provider_id: service_provider.id)
+
     visit opportunity_path(opportunity.id)
     expect(page).to have_link(country.name, href: 'https://www.gov.uk/government/publications/exporting-to-egypt')
     expect(page).to have_content('Your guide to exporting')
@@ -106,7 +109,7 @@ RSpec.feature 'Viewing an individual opportunity', :elasticsearch, :commit do
   scenario 'not all countries having links to exporting guide' do
     with_guide = create(:country, exporting_guide_path: '/government/publications/exporting-to-egypt')
     without_guide = create(:country)
-    opportunity = create(:opportunity, status: :publish, response_due_on: 3.months.from_now, countries: [with_guide, without_guide])
+    opportunity = create(:opportunity, status: :publish, response_due_on: 3.months.from_now, countries: [with_guide, without_guide], service_provider_id: service_provider.id)
 
     visit opportunity_path(opportunity.id)
     expect(page).to have_link(with_guide.name, href: 'https://www.gov.uk/government/publications/exporting-to-egypt')
@@ -124,7 +127,7 @@ RSpec.feature 'Viewing an individual opportunity', :elasticsearch, :commit do
 
   scenario 'aid funded opportunities have links to aid guidance' do
     aid_type = create(:type, slug: 'aid-funded-business', name: 'Aid Funded Business')
-    opportunity = create(:opportunity, status: :publish, response_due_on: 3.months.from_now, types: [aid_type])
+    opportunity = create(:opportunity, status: :publish, response_due_on: 3.months.from_now, types: [aid_type], service_provider_id: service_provider.id)
 
     visit opportunity_path(opportunity.id)
 
@@ -140,7 +143,7 @@ RSpec.feature 'Viewing an individual opportunity', :elasticsearch, :commit do
       { html: '<p>1</p>', selector: 'p' },
     ]
     acceptable_html_examples.each do |example|
-      op = create(:opportunity, status: 'publish', description: example[:html])
+      op = create(:opportunity, status: 'publish', description: example[:html], service_provider_id: service_provider.id)
       visit opportunity_path(op.id)
       expect(page).to have_css('.description ' + example[:selector])
     end
@@ -153,7 +156,7 @@ RSpec.feature 'Viewing an individual opportunity', :elasticsearch, :commit do
       { html: '<marquee>Funtimes</marquee>', selector: 'marquee' },
     ]
     unacceptable_html_examples.each do |example|
-      op = create(:opportunity, status: 'publish', description: example[:html])
+      op = create(:opportunity, status: 'publish', description: example[:html], service_provider_id: service_provider.id)
       visit opportunity_path(op.id)
       expect(page).not_to have_css('.opportunity__content ' + example[:selector])
     end
@@ -168,7 +171,7 @@ RSpec.feature 'Viewing an individual opportunity', :elasticsearch, :commit do
   They must be from Wimbledon.
 EOD
 
-    op = create(:opportunity, status: 'publish', description: example)
+    op = create(:opportunity, status: 'publish', description: example, service_provider_id: service_provider.id)
     visit opportunity_path(op.id)
     expect(page).to have_css('.description p:nth-last-child(3)')
   end

--- a/spec/presenters/admin_opportunity_presenter_spec.rb
+++ b/spec/presenters/admin_opportunity_presenter_spec.rb
@@ -5,11 +5,11 @@ require 'rails_helper'
 RSpec.describe AdminOpportunityPresenter do
   let(:editor) { create(:editor, role: :administrator) }
   let(:view_context) { admin_view_context(editor) }
+  let(:content) { get_content('opportunities/show', 'admin/opportunities') }
   let(:paths) { Rails.application.routes.url_helpers }
 
   describe '#edit_button' do
     it 'returns html for an Edit button' do
-      content = get_content('admin/opportunities')
       opportunity = create(:opportunity)
       presenter = AdminOpportunityPresenter.new(view_context, opportunity, content)
       button = presenter.edit_button
@@ -22,7 +22,6 @@ RSpec.describe AdminOpportunityPresenter do
 
   describe '#publishing_button' do
     it 'returns html for an Publishing button when status is publish' do
-      content = get_content('admin/opportunities')
       opportunity = create(:opportunity, status: :publish)
       presenter = AdminOpportunityPresenter.new(view_context, opportunity, content)
       button = presenter.publishing_button
@@ -33,7 +32,6 @@ RSpec.describe AdminOpportunityPresenter do
     end
 
     it 'returns html for an Publishing button when status is pending' do
-      content = get_content('admin/opportunities')
       opportunity = create(:opportunity, status: :pending)
       presenter = AdminOpportunityPresenter.new(view_context, opportunity, content)
       button = presenter.publishing_button
@@ -44,7 +42,6 @@ RSpec.describe AdminOpportunityPresenter do
     end
 
     it 'returns html for an Publishing button when status is trash' do
-      content = get_content('admin/opportunities')
       opportunity = create(:opportunity, status: :trash)
       presenter = AdminOpportunityPresenter.new(view_context, opportunity, content)
       button = presenter.publishing_button
@@ -55,7 +52,6 @@ RSpec.describe AdminOpportunityPresenter do
     end
 
     it 'returns empty string when status is not publish, pending, or trash' do
-      content = get_content('admin/opportunities')
       opportunity = create(:opportunity, status: :draft)
       presenter = AdminOpportunityPresenter.new(view_context, opportunity, content)
       button = presenter.publishing_button
@@ -66,7 +62,6 @@ RSpec.describe AdminOpportunityPresenter do
 
   describe '#trash_button' do
     it 'returns html for a Trash button' do
-      content = get_content('admin/opportunities')
       opportunity = create(:opportunity, status: :draft)
       presenter = AdminOpportunityPresenter.new(view_context, opportunity, content)
       button = presenter.trash_button
@@ -79,7 +74,6 @@ RSpec.describe AdminOpportunityPresenter do
 
   describe '#draft_button' do
     it 'returns html for a Draft button when statis is trash' do
-      content = get_content('admin/opportunities')
       opportunity = create(:opportunity, status: :trash)
       presenter = AdminOpportunityPresenter.new(view_context, opportunity, content)
       button = presenter.draft_button
@@ -90,7 +84,6 @@ RSpec.describe AdminOpportunityPresenter do
     end
 
     it 'returns html for a Draft button when status is pending' do
-      content = get_content('admin/opportunities')
       opportunity = create(:opportunity, status: :pending)
       presenter = AdminOpportunityPresenter.new(view_context, opportunity, content)
       button = presenter.draft_button
@@ -102,7 +95,6 @@ RSpec.describe AdminOpportunityPresenter do
 
 
     it 'returns blank string when status is neither trash or pending' do
-      content = get_content('admin/opportunities')
       opportunity = create(:opportunity, status: :draft)
       presenter = AdminOpportunityPresenter.new(view_context, opportunity, content)
       button = presenter.draft_button
@@ -113,7 +105,6 @@ RSpec.describe AdminOpportunityPresenter do
 
   describe '#pending_button' do
     it 'returns html for a Pending button when status is draft' do
-      content = get_content('admin/opportunities')
       opportunity = create(:opportunity, status: :draft)
       presenter = AdminOpportunityPresenter.new(view_context, opportunity, content)
       button = presenter.pending_button
@@ -124,7 +115,6 @@ RSpec.describe AdminOpportunityPresenter do
     end
 
     it 'returns empty string when status is not draft' do
-      content = get_content('admin/opportunities')
       opportunity = create(:opportunity, status: :pending)
       presenter = AdminOpportunityPresenter.new(view_context, opportunity, content)
       button = presenter.pending_button
@@ -135,7 +125,6 @@ RSpec.describe AdminOpportunityPresenter do
 
   describe '#button_to' do
     it 'returns html for a button' do
-      content = get_content('admin/opportunities')
       opportunity = create(:opportunity, status: :draft)
       presenter = AdminOpportunityPresenter.new(view_context, opportunity, content)
       button = presenter.button_to('some text', 'get', 'status_x')
@@ -164,7 +153,6 @@ RSpec.describe AdminOpportunityPresenter do
 
   describe '#author' do
     it 'returns author name or \'editor\' when author is nil' do
-      content = get_content('admin/opportunities')
       author = create(:editor, name: 'Fred')
       opportunity = create(:opportunity, author: author)
       presenter = AdminOpportunityPresenter.new(view_context, opportunity, content)

--- a/spec/presenters/opportunity_presenter_spec.rb
+++ b/spec/presenters/opportunity_presenter_spec.rb
@@ -3,10 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe OpportunityPresenter do
+  let(:content) { get_content('opportunities/show') }
+
   describe '#initialize' do
     it 'initializes a presenter' do
       opportunity = create(:opportunity, teaser: 'Opportunity teaser')
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.teaser).to eq('Opportunity teaser')
     end
@@ -16,7 +18,7 @@ RSpec.describe OpportunityPresenter do
     it 'does not change title if source is post and created before special date' do
       opportunity = create(:opportunity, title: 'foo', source: 0, created_at: Date.new(2018, 10, 7))
       opportunity.countries = create_list(:country, 2)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(opportunity.source).to eq('post')
       expect(opportunity.created_at).to eq(Date.new(2018, 10, 7))
@@ -25,7 +27,7 @@ RSpec.describe OpportunityPresenter do
 
     it 'does not change title if has no country assigned' do
       opportunity = create(:opportunity, title: 'foo', countries: [])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.title_with_country).to eq('foo')
     end
@@ -33,7 +35,7 @@ RSpec.describe OpportunityPresenter do
     it 'does not change title if only has no restricted country assigned' do
       country = create(:country, name: 'DIT HQ', id: 198)
       opportunity = create(:opportunity, title: 'foo', countries: [country])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.title_with_country).to eq('foo')
     end
@@ -41,7 +43,7 @@ RSpec.describe OpportunityPresenter do
     it 'adds "Multi Country" if opportunity has more than one country' do
       opportunity = create(:opportunity, title: 'foo', source: 1)
       opportunity.countries = create_list(:country, 2)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(opportunity.source).to_not eq('post')
       expect(presenter.title_with_country).to eq('Multi Country - foo')
@@ -50,7 +52,7 @@ RSpec.describe OpportunityPresenter do
     it 'adds country to opportunity title' do
       country = create(:country, name: 'Iran')
       opportunity = create(:opportunity, title: 'foo', source: 1, countries: [country], created_at: Date.new(2018, 10, 7))
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(opportunity.source).to_not eq('post')
       expect(opportunity.created_at).to eq(Date.new(2018, 10, 7))
@@ -63,7 +65,7 @@ RSpec.describe OpportunityPresenter do
       country1 = create(:country, name: 'Iran')
       country2 = create(:country, name: 'France')
       opportunity = create(:opportunity, countries: [country1, country2])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(opportunity.countries.size).to eq(2)
       expect(presenter.first_country).to eq('Iran')
@@ -71,7 +73,7 @@ RSpec.describe OpportunityPresenter do
 
     it 'returns blank string if no country' do
       opportunity = create(:opportunity, countries: [])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(opportunity.countries.size).to eq(0)
       expect(presenter.first_country).to eq('')
@@ -81,7 +83,7 @@ RSpec.describe OpportunityPresenter do
   describe '#description' do
     it 'returns opportunity.description' do
       opportunity = create(:opportunity, description: 'Opportunity description')
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.description).to eq('<p>Opportunity description</p>')
     end
@@ -90,7 +92,7 @@ RSpec.describe OpportunityPresenter do
   describe '#expires' do
     it 'returns formatted date string for response due time' do
       opportunity = create(:opportunity, response_due_on: '2019-02-01')
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.expires).to eq('01 February 2019')
     end
@@ -101,14 +103,14 @@ RSpec.describe OpportunityPresenter do
       enquiry1 = create(:enquiry)
       enquiry2 = create(:enquiry)
       opportunity = create(:opportunity, enquiries: [enquiry1, enquiry2])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.enquiries_total).to eq(2)
     end
 
     it 'returns zero when opportunity has no enquiries' do
       opportunity = create(:opportunity)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.enquiries_total).to eq(0)
     end
@@ -118,7 +120,7 @@ RSpec.describe OpportunityPresenter do
     it 'returns the correct opportunity type when only has one' do
       type = create(:type, name: 'Public Sector')
       opportunity = create(:opportunity, types: [type])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.type).to eq('Public Sector')
     end
@@ -127,7 +129,7 @@ RSpec.describe OpportunityPresenter do
       type1 = create(:type, name: 'Public Sector')
       type2 = create(:type, name: 'Public Sector')
       opportunity = create(:opportunity, types: [type1, type2])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.type).to eq('Public Sector and Public Sector')
     end
@@ -136,14 +138,14 @@ RSpec.describe OpportunityPresenter do
   describe '#sectors_as_string' do
     it 'returns empty string when sectors uninitialised' do
       opportunity = create(:opportunity)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.sectors_as_string).to eq('')
     end
 
     it 'returns empty string when has no sectors' do
       opportunity = create(:opportunity, sectors: [])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.sectors_as_string).to eq('')
     end
@@ -151,7 +153,7 @@ RSpec.describe OpportunityPresenter do
     it 'returns single sector as a string' do
       sector1 = create(:sector, name: 'Aerospace')
       opportunity = create(:opportunity, sectors: [sector1])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.sectors_as_string).to eq('Aerospace')
     end
@@ -160,7 +162,7 @@ RSpec.describe OpportunityPresenter do
       sector1 = create(:sector, name: 'Aerospace')
       sector2 = create(:sector, name: 'Agriculture')
       opportunity = create(:opportunity, sectors: [sector1, sector2])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.sectors_as_string).to eq('Aerospace and Agriculture')
     end
@@ -170,7 +172,7 @@ RSpec.describe OpportunityPresenter do
     it 'returns opportunity value' do
       value = create(:value, name: '100k')
       opportunity = create(:opportunity, values: [value])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.value).to eq('100k')
     end
@@ -179,7 +181,7 @@ RSpec.describe OpportunityPresenter do
       value1 = create(:value, name: '100k')
       value2 = create(:value, name: '150k')
       opportunity = create(:opportunity, values: [value1, value2])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.value).to eq('100k')
       expect(presenter.value).to_not eq('150k')
@@ -187,7 +189,7 @@ RSpec.describe OpportunityPresenter do
 
     it 'returns "Value unknown" when has no value' do
       opportunity = create(:opportunity)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.value).to eq('Value unknown')
     end
@@ -197,7 +199,7 @@ RSpec.describe OpportunityPresenter do
     it 'return contact email when has one' do
       contact = create(:contact, email: 'foo@bar.com')
       opportunity = create(:opportunity, contacts: [contact])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.contact).to eq('foo@bar.com')
     end
@@ -205,7 +207,7 @@ RSpec.describe OpportunityPresenter do
     it 'return nil when has no contact email' do
       contact = create(:contact, email: nil)
       opportunity = create(:opportunity, contacts: [contact])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.contact).to eq(nil)
     end
@@ -215,7 +217,7 @@ RSpec.describe OpportunityPresenter do
     it 'return true when has country guides' do
       countries = create_list(:country, 3, exporting_guide_path: "/file/#{Faker::Lorem.word}")
       opportunity = create(:opportunity, countries: countries)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.guides_available).to be_truthy
     end
@@ -223,7 +225,7 @@ RSpec.describe OpportunityPresenter do
     it 'return false when has no counry cguides' do
       countries = create_list(:country, 3, exporting_guide_path: nil)
       opportunity = create(:opportunity, countries: countries)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.guides_available).to be_falsey
     end
@@ -232,7 +234,7 @@ RSpec.describe OpportunityPresenter do
   describe '#country_guides' do
     it 'Returns an empty Array when there are no country guides' do
       opportunity = create(:opportunity, countries: create_list(:country, 3))
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.country_guides).to eql([])
     end
@@ -240,7 +242,7 @@ RSpec.describe OpportunityPresenter do
     it 'Returns a list of country guide links' do
       countries = create_list(:country, 3, exporting_guide_path: "/file/#{Faker::Lorem.word}")
       opportunity = create(:opportunity, countries: countries)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
       links = presenter.country_guides
 
       expect(links.length).to eql(3)
@@ -251,7 +253,7 @@ RSpec.describe OpportunityPresenter do
     it 'Returns a single "Country guides" link when has more than 5 country guides' do
       countries = create_list(:country, 6, exporting_guide_path: "/file/#{Faker::Lorem.word}")
       opportunity = create(:opportunity, countries: countries)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
       links = presenter.country_guides
 
       expect(links.length).to eql(1)
@@ -263,7 +265,7 @@ RSpec.describe OpportunityPresenter do
   describe '#industry_links' do
     it 'Returns a relevant link to when has an industry' do
       opportunity = create(:opportunity, sectors: [create(:sector, name: 'this is a sector name')])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
       links = presenter.industry_links
 
       expect(links).to include('href=') # should mean it is an html link
@@ -272,7 +274,7 @@ RSpec.describe OpportunityPresenter do
 
     it 'Returns multipls links when has more than one industry' do
       opportunity = create(:opportunity, sectors: [create(:sector, name: 'sector_1'), create(:sector, name: 'sector_2')])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
       links = presenter.industry_links
 
       expect(links).to include('href=') # should mean it is an html link
@@ -282,7 +284,7 @@ RSpec.describe OpportunityPresenter do
 
     it 'Returns an empty string when has no industries' do
       opportunity = create(:opportunity)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.industry_links).to eql('')
     end
@@ -291,7 +293,7 @@ RSpec.describe OpportunityPresenter do
   describe '#link_to_aid_funded' do
     it 'Returns HTML link if opportunity.aid_funded is true' do
       opportunity = create(:opportunity, types: [create(:type, slug: 'aid-funded-business')])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
       link = presenter.link_to_aid_funded('foo')
 
       expect(link).to include('href') # should mean it is a HTML link markup
@@ -301,7 +303,7 @@ RSpec.describe OpportunityPresenter do
 
     it 'Returns empty string if opportunity.aid_funded is false' do
       opportunity = create(:opportunity, types: [create(:type)])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
       link = presenter.link_to_aid_funded('foo')
 
       expect(link).to eql('')
@@ -311,14 +313,14 @@ RSpec.describe OpportunityPresenter do
   describe '#source' do
     it 'Returns true if the source matches passed string' do
       opportunity = create(:opportunity, source: 1)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.source('volume_opps')).to be_truthy
     end
 
     it 'Returns false if the source matches passed string' do
       opportunity = create(:opportunity, source: 1)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.source('foo')).to be_falsey
     end
@@ -327,7 +329,7 @@ RSpec.describe OpportunityPresenter do
   describe '#supplier_preferences' do
     it 'returns an empty string when has no supplier ids' do
       opportunity = create(:opportunity)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(opportunity.supplier_preference_ids.length).to eql(0)
       expect(presenter.supplier_preferences).to be_empty
@@ -336,7 +338,7 @@ RSpec.describe OpportunityPresenter do
     it 'returns a single supplier type as string when has one supplier id' do
       create(:supplier_preference, id: 1, slug: 'foo', name: 'foo')
       opportunity = create(:opportunity, supplier_preference_ids: [1])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(opportunity.supplier_preference_ids.length).to eql(1)
       expect(presenter.supplier_preferences).to eql('foo')
@@ -346,7 +348,7 @@ RSpec.describe OpportunityPresenter do
       create(:supplier_preference, id: 1, slug: 'foo', name: 'foo')
       create(:supplier_preference, id: 2, slug: 'bar', name: 'bar')
       opportunity = create(:opportunity, supplier_preference_ids: [1, 2])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(opportunity.supplier_preference_ids.length).to eql(2)
       expect(presenter.supplier_preferences).to eql('foo, bar')
@@ -359,7 +361,7 @@ RSpec.describe OpportunityPresenter do
       create(:supplier_preference, id: 2, slug: 'bar', name: 'bar')
       create(:supplier_preference, id: 3, slug: 'diddle', name: 'diddle')
       opportunity = create(:opportunity, supplier_preference_ids: [1, 2])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(opportunity.supplier_preference_ids).to_not be_nil
       expect(opportunity.supplier_preference_ids).to_not be_empty
@@ -368,7 +370,7 @@ RSpec.describe OpportunityPresenter do
 
     it 'returns false when opportunity does not have supplier preference ids' do
       opportunity = create(:opportunity)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(opportunity.supplier_preference_ids).to_not be_nil
       expect(opportunity.supplier_preference_ids).to be_empty
@@ -382,14 +384,14 @@ RSpec.describe OpportunityPresenter do
       # TODO: opportunity.rb currently stipulates CONTACTS_PER_OPPORTUNITY = 2
       # Believe that validation should change as per Jira[XOT-207]
       opportunity.contacts = []
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.buyer_details_empty?).to eq true
     end
 
     it 'returns false when has buyer name' do
       opportunity = create(:opportunity, buyer_address: 'Buckingham Palace')
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       # TODO: Remove contacts reset after Jira[XOT-207] to test this properly.
       opportunity.contacts = []
@@ -399,7 +401,7 @@ RSpec.describe OpportunityPresenter do
 
     it 'returns false when has buyer address' do
       opportunity = create(:opportunity, buyer_name: 'Fred Spendalot')
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       # TODO: Remove contacts reset after Jira[XOT-207] to test this properly.
       opportunity.contacts = []
@@ -409,7 +411,7 @@ RSpec.describe OpportunityPresenter do
 
     it 'returns false when has a contact' do
       opportunity = create(:opportunity)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       # Expect this to fail when Jira[XOT-207] complete.
       # Will need to create a fake contact(s) after that.
@@ -421,14 +423,14 @@ RSpec.describe OpportunityPresenter do
   describe '#translated?' do
     it 'returns false when opportunity has been translated' do
       opportunity = create(:opportunity, original_language: 'en')
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.translated?).to be_falsey
     end
 
     it 'returns true when opportunity has been translated' do
       opportunity = create(:opportunity, original_language: 'pl')
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.translated?).to be_truthy
     end
@@ -437,7 +439,7 @@ RSpec.describe OpportunityPresenter do
   describe '#published_date' do
     it 'returns correctly formatted published date as string' do
       opportunity = create(:opportunity, :published, first_published_at: Date.new(2015, 9, 15))
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.published_date).to eql('15 September 2015')
     end
@@ -446,14 +448,14 @@ RSpec.describe OpportunityPresenter do
   describe '#formatted_date' do
     it 'returns correctly formatted published date as string' do
       opportunity = create(:opportunity, :published, created_at: Date.new(2015, 9, 15))
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.formatted_date('created_at')).to eql('15 September 2015')
     end
 
     it 'returns empty string when no corresponding date property found' do
       opportunity = create(:opportunity, :published, first_published_at: Date.new(2015, 9, 15))
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.formatted_date('foo')).to eql('')
     end
@@ -464,7 +466,7 @@ RSpec.describe OpportunityPresenter do
     it 'returns sign off content for Post opp with third-party URL' do
       provider = create(:service_provider)
       opportunity = create(:opportunity, target_url: '/foo/bar/')
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, content)
       lines = presenter.sign_off_content(provider)
 
       expect(lines.length).to eq(1)
@@ -474,7 +476,7 @@ RSpec.describe OpportunityPresenter do
     # source('volume_opps')
     it 'returns sign off content for Open Opp' do
       opportunity = create(:opportunity, source: 'volume_opps')
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, content)
       lines = presenter.sign_off_content
 
       expect(lines.length).to eq(1)
@@ -486,7 +488,7 @@ RSpec.describe OpportunityPresenter do
       country = create(:country)
       provider = create(:service_provider, country_id: country.id, partner: 'partner name')
       opportunity = create(:opportunity)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, content)
       lines = presenter.sign_off_content(provider)
       partner_name = provider.partner
       country_name = provider.country.name
@@ -500,7 +502,7 @@ RSpec.describe OpportunityPresenter do
     it 'returns standard DIT sign off content for specific providers' do
       provider = create(:service_provider, name: 'DIT HQ')
       opportunity = create(:opportunity)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, content)
       lines = presenter.sign_off_content(provider)
 
       expect(lines.length).to eq(1)
@@ -512,7 +514,7 @@ RSpec.describe OpportunityPresenter do
       country = create(:country, name: 'Czech Republic')
       provider = create(:service_provider, name: 'Czech Republic Prague', country_id: country.id)
       opportunity = create(:opportunity)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, content)
       lines = presenter.sign_off_content(provider)
       country_name = provider.country.name
 
@@ -523,7 +525,7 @@ RSpec.describe OpportunityPresenter do
       country = create(:country, name: 'USA')
       provider = create(:service_provider, name: 'United States Chicago', country_id: country.id)
       opportunity = create(:opportunity)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, content)
       lines = presenter.sign_off_content(provider)
       country_name = provider.country.name
 
@@ -537,7 +539,7 @@ RSpec.describe OpportunityPresenter do
       country = create(:country, name: 'Cameroon', region_id: region.id)
       provider = create(:service_provider, name: 'Cameroon Yaounde', country_id: country.id)
       opportunity = create(:opportunity)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, content)
       lines = presenter.sign_off_content(provider)
       country_name = provider.country.name
 
@@ -549,7 +551,7 @@ RSpec.describe OpportunityPresenter do
       country = create(:country, name: 'South Africa', region_id: region.id)
       provider = create(:service_provider, name: 'South Africa Johannesburg', country_id: country.id)
       opportunity = create(:opportunity)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, content)
       lines = presenter.sign_off_content(provider)
       country_name = provider.country.name
 
@@ -562,7 +564,7 @@ RSpec.describe OpportunityPresenter do
       country = create(:country, name: 'France')
       provider = create(:service_provider, country_id: country.id)
       opportunity = create(:opportunity)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, content)
       lines = presenter.sign_off_content(provider)
       country_name = provider.country.name
 
@@ -574,7 +576,7 @@ RSpec.describe OpportunityPresenter do
       country = create(:country, name: 'France')
       provider = create(:service_provider, country_id: country.id)
       opportunity = create(:opportunity, service_provider_id: provider.id)
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, content)
       lines = presenter.sign_off_content
       country_name = provider.country.name
 
@@ -588,7 +590,7 @@ RSpec.describe OpportunityPresenter do
       contact1 = create(:contact, email: 'foo1@bar.com')
       contact2 = create(:contact, email: 'foo2@bar.com')
       opportunity = create(:opportunity, contacts: [contact1, contact2])
-      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity)
+      presenter = OpportunityPresenter.new(ActionController::Base.helpers, opportunity, [])
 
       expect(presenter.send(:contact_email)).to eq('foo1@bar.com')
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,8 +22,12 @@ module Helpers
     end
   end
 
-  def get_content(file)
-    YAML.load_file(File.join(Rails.root.to_s, 'app', 'content/') + file + '.yml')
+  def get_content(*files)
+    content = {}
+    files.each do |file|
+      content = content.merge YAML.load_file(File.join(Rails.root.to_s, 'app', 'content/') + file + '.yml')
+    end
+    content
   end
 end
 


### PR DESCRIPTION
A lot of changes here basically just to get the extra Sign Off lines to also show on Admin views, but without repeating the content across files. 

Had to start by updating the OpportunityPresenter (which has the sign off lines) to work from a content file. That led to a need to test properly, so there are some test fixes here (which also include fixes for some files that were broken by unrelated changes). 

Lastly, with the mechanism updated and everything coming from a content file, the actual addition of extra Sign Off line content was very easy and leaves views working from the same shared code.

A lot of effort but hopefully worth it in the long run.
