### PR TITLE
(fix) rollback elastic_search_url

### DIFF
--- a/config/initializers/elastic_search.rb
+++ b/config/initializers/elastic_search.rb
@@ -2,7 +2,7 @@
 Hashie.logger = Logger.new(nil)
 
 Elasticsearch::Model.client = if Rails.env.production?
-                                Elasticsearch::Client.new(url: JSON.parse(ENV['VCAP_SERVICES'])["elasticsearch"][0]["credentials"]["uri"])
+                                Elasticsearch::Client.new(url: Figaro.env.elastic_search_url)
                               else
                                 Elasticsearch::Client.new host: '127.0.0.1:9200'
                               end


### PR DESCRIPTION
b/c Gov PaaS only has ES up to medium size and we need L