### PR TITLE
Bug/hotfix respond to mismatch error 30 june (#735)

### DIFF
--- a/app/controllers/api/activity_stream_controller.rb
+++ b/app/controllers/api/activity_stream_controller.rb
@@ -332,7 +332,6 @@ module Api
 
       def respond(code, message)
         respond_to do |format|
-          response.headers['Content-Type'] = 'application/json'
           error_object = {
             message: message,
           }
@@ -342,7 +341,6 @@ module Api
 
       def respond_200(contents)
         respond_to do |format|
-          response.headers['Content-Type'] = 'application/activity+json'
           format.json { render status: :ok, json: Yajl::Encoder.encode(contents) }
         end
       end


### PR DESCRIPTION
* Bug/fix enquiry response ambiguity error (#726)

* Add index to subscription notifications and improve seeds (#723)

* Fix bug

* Hotfix - remove index adding (#728)

* update migrtions

* remove adding index

* Fix           response.headers['Content-Type'] = 'application/json'
 causing errors