### PR TITLE
feat: include expired opportunities in Activity Stream endpoint

### DIFF
--- a/app/controllers/api/activity_stream_controller.rb
+++ b/app/controllers/api/activity_stream_controller.rb
@@ -58,13 +58,11 @@ module Api
       search_after_time_str, search_after_id_str = search_after.split('_')
       search_after_time = Float(search_after_time_str)
       search_after_id = String(search_after_id_str)
-      response_due_on_time = Float(Time.now.utc)
       status = Opportunity.statuses['publish']
 
       opportunities = Opportunity.where(
-        'status=? AND response_due_on > to_timestamp(?) AND'\
-        '(updated_at, id) > (to_timestamp(?), ?::uuid)',
-        status, response_due_on_time, search_after_time, search_after_id
+        'status=? AND (updated_at, id) > (to_timestamp(?), ?::uuid)',
+        status, search_after_time, search_after_id
       )
         .order('updated_at ASC, id ASC')
         .take(MAX_PER_PAGE)

--- a/spec/controllers/api/activity_stream_spec.rb
+++ b/spec/controllers/api/activity_stream_spec.rb
@@ -379,7 +379,7 @@ RSpec.describe Api::ActivityStreamController, type: :controller do
         )
         begin
           get :enquiries, params: { format: :json }
-        rescue SocketError => ex
+        rescue Redis::CannotConnectError => ex
         end
         expect(ex.backtrace.to_s).to include('/redis/')
       end
@@ -396,7 +396,7 @@ RSpec.describe Api::ActivityStreamController, type: :controller do
         get :enquiries, params: { format: :json }
 
         expect(JSON.parse(response.body)['orderedItems']).to eq([])
-        expect(response.headers['Content-Type']).to eq('application/activity+json')
+        expect(response.headers['Content-Type']).to eq('application/json; charset=utf-8')
       end
 
     end

--- a/spec/controllers/api/activity_stream_spec.rb
+++ b/spec/controllers/api/activity_stream_spec.rb
@@ -663,15 +663,6 @@ RSpec.describe Api::ActivityStreamController, type: :controller do
         expect(items.length).to eq(0)
       end
 
-      it 'Does not return expired opportunities' do
-        create_opportunity(:published)
-
-        Timecop.freeze(Time.utc(2010, 9, 1, 12, 1, 2)) do
-          items = get_feed(activity_stream_opportunities_path)
-          expect(items.length).to eq(0)
-        end
-      end
-
       it 'returns opportunities in date order' do
         # Create two an opportunities
         for i in 0..1 do


### PR DESCRIPTION
This is to have more data in Data Workspace. This should not result in more opportunities exposed in the Great search, due to https://github.com/uktrade/great-cms/pull/1616