### PR TITLE
KLS-1487 cflinux4 upgrade

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,3 +4,4 @@ applications:
       - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.61
     health-check-type: http
     health-check-http-endpoint: /export-opportunities/check
+    stack: cflinuxfs3


### PR DESCRIPTION
Enforcing `cflinux3` until the runtime is upgraded to Ruby 3.x