### PR TITLE
Remove IP check as handled by HAWK

### DIFF
--- a/app/controllers/api/activity_stream_controller.rb
+++ b/app/controllers/api/activity_stream_controller.rb
@@ -316,12 +316,6 @@ module Api
       end
 
       def authenticate(request)
-        remote_ips = request.headers['X-Forwarded-For'].gsub(/\s+/, '').split(',')
-        return [false, 'Connecting from unauthorized IP'] unless remote_ips.length >= 2
-
-        authorized_ip_addresses = Figaro.env.ACTIVITY_STREAM_IP_WHITELIST.split(',')
-        return [false, 'Connecting from unauthorized IP'] unless authorized_ip_addresses.include?(remote_ips[-2])
-
         return [false, 'Authorization header is missing'] unless request.headers.key?('Authorization')
 
         parsed_header_array = request.headers['Authorization'].scan(/([a-z]+)="([^"]+)"/)

--- a/spec/controllers/api/activity_stream_spec.rb
+++ b/spec/controllers/api/activity_stream_spec.rb
@@ -36,32 +36,6 @@ RSpec.describe Api::ActivityStreamController, type: :controller do
     end
 
     describe "authorization" do
-
-      it 'responds with a 401 error if connecting from unauthorized IP' do
-        # The whitelist is 0.0.0.0, and we reject all requests that don't have
-        # 0.0.0.0 as the second-to-last IP in X-Fowarded-For, as this isn't
-        # spoofable in PaaS
-        @request.headers['X-Forwarded-For'] = '1.2.3.4'
-        get :enquiries, params: { format: :json }
-        expect(response.body).to eq(%({"message":"Connecting from unauthorized IP"}))
-
-        @request.headers['X-Forwarded-For'] = '0.0.0.0'
-        get :enquiries, params: { format: :json }
-        expect(response.body).to eq(%({"message":"Connecting from unauthorized IP"}))
-
-        @request.headers['X-Forwarded-For'] = '1.2.3.4, 0.0.0.0'
-        get :enquiries, params: { format: :json }
-        expect(response.body).to eq(%({"message":"Connecting from unauthorized IP"}))
-
-        @request.headers['X-Forwarded-For'] = '0.0.0.0, 1.2.3.4, 123.123.123'
-        get :enquiries, params: { format: :json }
-        expect(response.body).to eq(%({"message":"Connecting from unauthorized IP"}))
-
-        @request.headers['X-Forwarded-For'] = '1.2.3.4, 123.123.123, 0.0.0.0'
-        get :enquiries, params: { format: :json }
-        expect(response.body).to eq(%({"message":"Connecting from unauthorized IP"}))
-      end
-
       it 'responds with a 401 error if Authorization header is not set' do
         @request.headers['X-Forwarded-For'] = '0.0.0.0, 1.2.3.4'
         get :enquiries, params: { format: :json }


### PR DESCRIPTION
We can remove the IP checks as HAWK will deal with the authentication. Similarly  to here https://github.com/uktrade/directory-sso/pull/837/files where directory sso relies on just HAWK to authenticate 