### PR TITLE
Generate enquiries report as background job

### DIFF
--- a/app/controllers/admin/enquiries_controller.rb
+++ b/app/controllers/admin/enquiries_controller.rb
@@ -32,7 +32,7 @@ class Admin::EnquiriesController < Admin::BaseController
       format.csv do
         enquiries = policy_scope(Enquiry).includes(:enquiry_response).where('enquiries.created_at >= ?', @enquiry_form.from).where('enquiries.created_at < ?', @enquiry_form.to).order('enquiries.created_at DESC')
         zip_file_enquiries_cutoff_env_var = Figaro.env.zip_file_enquiries_cutoff ? Figaro.env.zip_file_enquiries_cutoff!.to_i : 6000
-        SendEnquiriesReportToMatchingAdminUser.perform_now(current_editor.email, enquiries.pluck('enquiries.id'), @enquiry_form.from, @enquiry_form.to, zip_file_enquiries_cutoff_env_var) if @enquiry_form.dates?
+        SendEnquiriesReportToMatchingAdminUser.perform_later(current_editor.email, enquiries.pluck('enquiries.id'), @enquiry_form.from, @enquiry_form.to, zip_file_enquiries_cutoff_env_var) if @enquiry_form.dates?
         redirect_to admin_enquiries_path, notice: 'The Enquiries report has been emailed. If you have requested a large amount of data, the report will be sent as sections in separate emails.'
       end
     end

--- a/app/workers/send_enquiries_report_to_matching_admin_user.rb
+++ b/app/workers/send_enquiries_report_to_matching_admin_user.rb
@@ -1,6 +1,7 @@
 require 'matrix'
 require 'csv'
 require 'zip'
+require 'tempfile'
 
 class SendEnquiriesReportToMatchingAdminUser < ActiveJob::Base
   sidekiq_options retry: false
@@ -13,27 +14,90 @@ class SendEnquiriesReportToMatchingAdminUser < ActiveJob::Base
 
     csv = EnquiryCSV.new(@enquiries)
 
-    csv_file = []
-    csv.each do |row|
-      csv_file << row
+    # Count the number of rows to determine if we need to zip
+    row_count = 1 # Start with 1 for the header
+    @enquiries.find_each { row_count += 1 }
+
+    if row_count > zip_file_enquiries_cutoff.to_i
+      # Process in chunks to avoid loading everything into memory
+      process_in_chunks(csv, current_editor_email, zip_file_enquiries_cutoff_ses_limit)
+    else
+      # For smaller datasets, collect the CSV content
+      csv_content = ""
+      csv.each do |row|
+        csv_content << row
+      end
+
+      # Send the CSV content directly
+      EnquiriesReportMailer.send_report(csv_content, current_editor_email, false).deliver_later!
     end
-    if csv_file.length > zip_file_enquiries_cutoff.to_i
+  end
 
-      header = csv_file[0]
-      data = csv_file.drop(0)
+  def process_in_chunks(csv, current_editor_email, chunk_size)
+    # Get the header first
+    header = nil
+    csv_enumerator = csv.each
+    header = csv_enumerator.next if csv_enumerator.respond_to?(:next)
 
-      while data.length.positive?
-        # generate a unique temp filename for zipping
-        zipped_filename = 'enquiries_' + current_editor_email.gsub(/[^0-9A-Za-z]/, '') + '_' + Time.new.to_i.to_s + '_' + data.length.to_i.to_s
+    # Process in chunks
+    chunk_counter = 0
 
-        Zip::File.open(zipped_filename + '.zip', Zip::File::CREATE) do |zipfile|
-          zipfile.get_output_stream(zipped_filename + '.csv') { |f| f.puts [header] + data.shift(zip_file_enquiries_cutoff_ses_limit) }
+    # Generate a base filename
+    base_filename = 'enquiries_' + current_editor_email.gsub(/[^0-9A-Za-z]/, '') + '_' + Time.now.to_i.to_s
+
+    # Create a temporary directory for our files
+    temp_dir = Dir.mktmpdir
+
+    begin
+      current_file = File.join(temp_dir, "#{base_filename}_#{chunk_counter}.csv")
+      current_zip = File.join(temp_dir, "#{base_filename}_#{chunk_counter}.zip")
+
+      File.open(current_file, 'w') do |file|
+        # Write the header
+        file.write(header) if header
+
+        # Write rows in batches
+        row_counter = 0
+        csv_enumerator.each do |row|
+          file.write(row)
+          row_counter += 1
+
+          # If we've reached the chunk size, zip and send
+          if row_counter >= chunk_size
+            file.close
+
+            # Create zip file
+            Zip::File.open(current_zip, Zip::File::CREATE) do |zipfile|
+              zipfile.add(File.basename(current_file), current_file)
+            end
+
+            # Send the email
+            EnquiriesReportMailer.send_report(current_zip, current_editor_email, true).deliver_later!
+
+            # Prepare for the next chunk
+            chunk_counter += 1
+            current_file = File.join(temp_dir, "#{base_filename}_#{chunk_counter}.csv")
+            current_zip = File.join(temp_dir, "#{base_filename}_#{chunk_counter}.zip")
+
+            # Start a new file with the header
+            file = File.open(current_file, 'w')
+            file.write(header) if header
+            row_counter = 0
+          end
+        end
+      end
+
+      # Send the last chunk if it has any data
+      if File.size?(current_file) && File.size(current_file) > (header ? header.length : 0)
+        Zip::File.open(current_zip, Zip::File::CREATE) do |zipfile|
+          zipfile.add(File.basename(current_file), current_file)
         end
 
-        EnquiriesReportMailer.send_report(zipped_filename + '.zip', current_editor_email, true).deliver_later!
+        EnquiriesReportMailer.send_report(current_zip, current_editor_email, true).deliver_later!
       end
-    else
-      EnquiriesReportMailer.send_report(csv_file, current_editor_email, false).deliver_later!
+    ensure
+      # Clean up temporary files
+      FileUtils.remove_entry(temp_dir) if temp_dir
     end
   end
 


### PR DESCRIPTION
The original process was to load all CSV data into memory at once, which would cause the process to be killed due to limited memory.

This PR enables processing data in smaller chunks and uses files for temporary storage, now as a background job.