### PR TITLE
Update csat created_at to be feedback_submission_date for activity stream

### DIFF
--- a/app/controllers/api/activity_stream_controller.rb
+++ b/app/controllers/api/activity_stream_controller.rb
@@ -211,7 +211,7 @@ module Api
 
         {
           'id': csat_feedback.id,
-          'created_at': csat_feedback.created_at.to_datetime.rfc3339,
+          'feedback_submission_date': csat_feedback.created_at.to_datetime.rfc3339,
           'type': prefix,
           'url': csat_feedback.url,
           'user_journey': csat_feedback.user_journey,

--- a/spec/controllers/api/activity_stream_spec.rb
+++ b/spec/controllers/api/activity_stream_spec.rb
@@ -804,7 +804,7 @@ RSpec.describe Api::ActivityStreamController, type: :controller do
         expect(item['type']).to eq('Update')
 
         expect(item_object['id']).to eq(feedback.id)
-        expect(item_object['created_at']).to eq(feedback.created_at.to_datetime.rfc3339)
+        expect(item_object['feedback_submission_date']).to eq(feedback.created_at.to_datetime.rfc3339)
         expect(item_object['type']).to eq('dit:exportOpportunities:HCSATFeedbackData')
         expect(item_object['url']).to eq('www.bob.com')
         expect(item_object['user_journey']).to eq('OPPORTUNITY')


### PR DESCRIPTION
Ex-ops HCSAT should have a `feedback_submission_date` which is the `created_at` date in the ex-ops table. The fields should match the fields for domestic Ex-ops.

@divyaparameswaran There will most likely need to be a change in air flow repo to now match against the field renaming :) 