### PR TITLE
Find and replace great domain with business

### DIFF
--- a/app/presenters/opportunity_presenter.rb
+++ b/app/presenters/opportunity_presenter.rb
@@ -99,9 +99,13 @@ class OpportunityPresenter < PagePresenter
                            target: '_blank', rel: 'noopener noreferrer', title: 'Opens in a new window'))
     else
       guides.each do |country|
+        # TODO: Remove this once all countries are updated with a rake task, so any references to great.gov.uk are replaced with business.gov.uk
+
+        guide_path = country.exporting_guide_path.gsub('great.gov.uk', fetch_domain)
+
         link = link_to(country.name,
-                       country.exporting_guide_path,
-                       target: '_blank', rel: 'noopener noreferrer', title: 'Opens in a new window')
+                         guide_path,
+                         target: '_blank', rel: 'noopener noreferrer', title: 'Opens in a new window')
         links.push(link.html_safe)
       end
     end


### PR DESCRIPTION
When a Country is created a `exporting_guide_path` is added. For most of the 203 countries is pointing to `https://www.great.gov.uk/markets/{MARKET_NAME}`. As we are under time pressure the quick fix for this is to find and replace `great.gov.uk` with the `fetch_domain` method so the url should work in all envs (unless it was not created in lower envs as data is not amazing across the lower envs)

Once we have removed great.gov.uk and only use one domain we will have a follow up task to run a rake task to update the data in the database so any occurrence of great.gov.uk is replaced with business.gov.uk for data consistency. We can revert this PR