### PR TITLE
Update URL to go to different markets page

### DIFF
--- a/app/presenters/opportunity_presenter.rb
+++ b/app/presenters/opportunity_presenter.rb
@@ -95,17 +95,18 @@ class OpportunityPresenter < PagePresenter
     links = []
     if guides.length > 5
       links.push(h.link_to('Country guides',
-                           "https://www.#{fetch_domain}/markets/",
+                           "https://www.#{fetch_domain}#{fetch_domain == 'great.gov.uk' ? '/markets/' : '/export-from-uk/markets/'}",
                            target: '_blank', rel: 'noopener noreferrer', title: 'Opens in a new window'))
     else
       guides.each do |country|
         # TODO: Remove this once all countries are updated with a rake task, so any references to great.gov.uk are replaced with business.gov.uk
 
         guide_path = country.exporting_guide_path.gsub('great.gov.uk', fetch_domain)
+        guide_path = guide_path.gsub('/markets/', '/export-from-uk/markets/') unless fetch_domain == 'great.gov.uk'
 
         link = link_to(country.name,
-                         guide_path,
-                         target: '_blank', rel: 'noopener noreferrer', title: 'Opens in a new window')
+                       guide_path,
+                       target: '_blank', rel: 'noopener noreferrer', title: 'Opens in a new window')
         links.push(link.html_safe)
       end
     end


### PR DESCRIPTION
Depending on the env, the markets page has a different URL. So if not great.gov.uk we will go to `/export-from-uk/markets/`